### PR TITLE
Feature/migration to EF core3.1

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,33 @@
+version: 3.0.{build}
+pull_requests:
+  do_not_increment_build_number: true
+image: Visual Studio 2019
+dotnet_csproj:
+  patch: true
+  file: '**\*.csproj'
+  version: '{version}'
+  version_prefix: '{version}'
+  package_version: '{version}'
+  assembly_version: '{version}'
+  file_version: '{version}'
+  informational_version: '{version}'
+branches:
+  only:
+    - master
+only_commits:
+  files:
+    - src/
+build_script:
+- cmd: dotnet build ./src/EfCore.UnitOfWork.sln
+test_script:
+- cmd: dotnet test ./src/EfCore.UnitOfWork.UnitTests/EfCore.UnitOfWork.UnitTests.csproj
+artifacts:
+- path: '**/*.nupkg'
+  name: Package
+deploy:
+- provider: NuGet
+  api_key:
+    secure: 3RdOpnDeJt65sQ2miIHOjnTpTezj3XPwfp0U5uVptqBwmIBe/14os4dKDfZJqcQ4
+  skip_symbols: true
+  on:
+    branch: master

--- a/src/EfCore.UnitOfWork.UnitTests/EfCore.UnitOfWork.UnitTests.csproj
+++ b/src/EfCore.UnitOfWork.UnitTests/EfCore.UnitOfWork.UnitTests.csproj
@@ -1,16 +1,16 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <RootNamespace>EfCore.UnitOfWork.UnitTests</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="5.9.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="2.2.4" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.0" />
+    <PackageReference Include="FluentAssertions" Version="5.10.3" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.1.9" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/src/EfCore.UnitOfWork.UnitTests/Entities/Country.cs
+++ b/src/EfCore.UnitOfWork.UnitTests/Entities/Country.cs
@@ -8,7 +8,6 @@ namespace EfCore.UnitOfWork.UnitTests.Entities
         [Key]
         public int Id { get; set; }
         public string Name { get; set; }
-
         public List<City> Cities { get; set; }
     }
 }

--- a/src/EfCore.UnitOfWork.UnitTests/InMemoryDbContext.cs
+++ b/src/EfCore.UnitOfWork.UnitTests/InMemoryDbContext.cs
@@ -13,11 +13,12 @@ namespace EfCore.UnitOfWork.UnitTests
 
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
         {
-            var name = $"{typeof(InMemoryDbContext).Name}_{Guid.NewGuid()}";
+            var name = $"{nameof(InMemoryDbContext)}_{Guid.NewGuid()}";
 
             var serviceProvider = new ServiceCollection()
                 .AddEntityFrameworkInMemoryDatabase()
                 .BuildServiceProvider();
+            
             optionsBuilder.UseInMemoryDatabase(name)
                 .ConfigureWarnings(warnings => warnings.Ignore(InMemoryEventId.TransactionIgnoredWarning))
                 .UseInternalServiceProvider(serviceProvider);

--- a/src/EfCore.UnitOfWork.UnitTests/RepositoryTests.cs
+++ b/src/EfCore.UnitOfWork.UnitTests/RepositoryTests.cs
@@ -11,7 +11,10 @@ namespace EfCore.UnitOfWork.UnitTests
     {
         private readonly RepositoryFixture _fixture;
 
-        public RepositoryTests(RepositoryFixture fixture) => _fixture = fixture;
+        public RepositoryTests(RepositoryFixture fixture)
+        {
+            _fixture = fixture;
+        }
 
         [Fact]
         public void Should_GetList_ResolveTheRightSetOfDataFromContext()
@@ -20,14 +23,14 @@ namespace EfCore.UnitOfWork.UnitTests
             var repository = _fixture.CreateRepository<City>();
 
             // Act
-            var actual = repository.GetList(t => t.Name == "C", q => q.Include(t => t.Country).PagedBy(0,1));
+            var actual = repository.GetList(t => t.Name == "C", q => q.Include(t => t.Country).PagedBy(0, 1));
 
             // Assert
 
             actual.Should().HaveCount(1)
                 .And.Contain(m => m.Country != null && m.CountryId != 0 && m.Country.Name == "A" && m.Country.Id == 1);
-        }          
-        
+        }
+
         [Fact]
         public async Task Should_GetListAsync_ResolveTheRightSetOfDataFromContext()
         {
@@ -35,14 +38,15 @@ namespace EfCore.UnitOfWork.UnitTests
             var repository = _fixture.CreateRepository<City>();
 
             // Act
-            var actual = await repository.GetListAsync(t => t.Name == "C", q => q.Include(t => t.Country).PagedBy(0,1));
+            var actual =
+                await repository.GetListAsync(t => t.Name == "C", q => q.Include(t => t.Country).PagedBy(0, 1));
 
             // Assert
 
             actual.Should().HaveCount(1)
                 .And.Contain(m => m.Country != null && m.CountryId != 0 && m.Country.Name == "A" && m.Country.Id == 1);
-        }            
-        
+        }
+
         [Fact]
         public void Should_GetProjectedList_WithProjection_ResolveTheSmallerSetOfDataFromContext()
         {
@@ -55,8 +59,8 @@ namespace EfCore.UnitOfWork.UnitTests
             // Assert
             actual.Should().HaveCount(1)
                 .And.Contain(m => m == "C");
-        } 
-        
+        }
+
         [Fact]
         public async Task Should_GetProjectedListAsync_WithProjection_ResolveTheSmallerSetOfDataFromContext()
         {
@@ -64,13 +68,15 @@ namespace EfCore.UnitOfWork.UnitTests
             var repository = _fixture.CreateRepository<City>();
 
             // Act
-            var actual = await repository.GetProjectedListAsync(t => t.Name == "C", m => m.Name, q => q.Include(t => t.Country));
+            var actual =
+                await repository.GetProjectedListAsync(t => t.Name == "C", m => m.Name);
+                // await repository.GetProjectedListAsync(t => t.Name == "C", m => m.Name, q => q.Include(t => t.Country));
 
             // Assert
             actual.Should().HaveCount(1)
                 .And.Contain(m => m == "C");
-        }        
-        
+        }
+
         [Fact]
         public void Should_GetFirstOrDefault_ResolveTheRightSetOfDataFromContext()
         {
@@ -84,9 +90,9 @@ namespace EfCore.UnitOfWork.UnitTests
             actual.Should().NotBeNull();
             actual.Name.Should().Be("C");
             actual.CountryId.Should().Be(1);
-            actual.Country.Should().BeEquivalentTo(new Country{ Name= "A", Id = 1}, m => m.Excluding(t => t.Cities));
-        }          
-        
+            actual.Country.Should().BeEquivalentTo(new Country {Name = "A", Id = 1}, m => m.Excluding(t => t.Cities));
+        }
+
         [Fact]
         public async Task Should_GetFirstOrDefaultAsync_ResolveTheRightSetOfDataFromContext()
         {
@@ -100,51 +106,52 @@ namespace EfCore.UnitOfWork.UnitTests
             actual.Should().NotBeNull();
             actual.Name.Should().Be("C");
             actual.CountryId.Should().Be(1);
-            actual.Country.Should().BeEquivalentTo(new Country{ Name= "A", Id = 1}, m => m.Excluding(t => t.Cities));
-        }   
-        
+            actual.Country.Should().BeEquivalentTo(new Country {Name = "A", Id = 1}, m => m.Excluding(t => t.Cities));
+        }
+
         [Fact]
         public async Task Should_GetFirstOrDefaultAsync_ReturnsMultipleLevelOfHierarchyWhenItsIncludedInQuery()
         {
             // Arrange
             var repository = _fixture.CreateRepository<Country>();
-            
+
             // Act
-            var actual = await repository.GetFirstOrDefaultAsync(t => t.Name == "A", country => country.Include(c => c.Cities).ThenInclude(city => city.Towns));
+            var actual = await repository.GetFirstOrDefaultAsync(t => t.Name == "A",
+                country => country.Include(c => c.Cities).ThenInclude(city => city.Towns));
 
             // Assert
             actual.Should().NotBeNull();
             actual.Cities.Should().HaveCount(3).And.Contain(m => m.Towns.Count == 1);
-        }        
-        
+        }
+
         [Fact]
         public void Should_Find_ReturnsCertainEntityByIdentifier()
         {
             // Arrange
             var repository = _fixture.CreateRepository<Country>();
-            
+
             // Act
             var actual = repository.Find(1);
 
             // Assert
             actual.Should().NotBeNull();
             actual.Name.Should().Be("A");
-        }  
-        
+        }
+
         [Fact]
         public async Task Should_FindAsync_ReturnsCertainEntityByIdentifier()
         {
             // Arrange
             var repository = _fixture.CreateRepository<Country>();
-            
+
             // Act
             var actual = await repository.FindAsync(1);
 
             // Assert
             actual.Should().NotBeNull();
             actual.Name.Should().Be("A");
-        }  
-        
+        }
+
         [Theory]
         [InlineData("A", 1)]
         [InlineData("B", 1)]
@@ -153,12 +160,12 @@ namespace EfCore.UnitOfWork.UnitTests
         {
             // Arrange
             var repository = _fixture.CreateRepository<Country>();
-            
+
             // Act
             var actual = repository.Count(m => m.Name == phrase);
 
             // Assert
             actual.Should().Be(expectedCount);
-        }   
+        }
     }
 }

--- a/src/EfCore.UnitOfWork/EfCore.UnitOfWork.csproj
+++ b/src/EfCore.UnitOfWork/EfCore.UnitOfWork.csproj
@@ -8,15 +8,14 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageId>EfCore.UnitOfWork</PackageId>
     <PackageProjectUrl>https://github.com/moattarwork/UnitOfWork</PackageProjectUrl>
-    <PackageLicenseUrl>https://github.com/moattarwork/UnitOfWork/blob/master/LICENSE</PackageLicenseUrl>
     <RepositoryUrl>moattarwork</RepositoryUrl>
     <RootNamespace>EfCore.UnitOfWork</RootNamespace>
     <PackageVersion>1.0.0</PackageVersion>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.AutoHistory" Version="2.1.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="2.2.4" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="2.0.3" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.AutoHistory" Version="3.1.3" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="3.1.9" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.9" />
   </ItemGroup>
 </Project>

--- a/src/EfCore.UnitOfWork/IRepository.cs
+++ b/src/EfCore.UnitOfWork/IRepository.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 
 namespace EfCore.UnitOfWork
 {
@@ -11,13 +12,13 @@ namespace EfCore.UnitOfWork
     {
         IQueryable<TEntity> FromSql(string sql, params object[] parameters);
         TEntity Find(params object[] keyValues);
-        Task<TEntity> FindAsync(params object[] keyValues);
-        Task<TEntity> FindAsync(object[] keyValues, CancellationToken cancellationToken);
+        ValueTask<TEntity> FindAsync(params object[] keyValues);
+        ValueTask<TEntity> FindAsync(object[] keyValues, CancellationToken cancellationToken);
         int Count(Expression<Func<TEntity, bool>> predicate = null);
         void Insert(TEntity entity);
         void Insert(params TEntity[] entities);
         void Insert(IEnumerable<TEntity> entities);
-        Task InsertAsync(TEntity entity, CancellationToken cancellationToken = default);
+        ValueTask<EntityEntry<TEntity>> InsertAsync(TEntity entity, CancellationToken cancellationToken = default);
         Task InsertAsync(params TEntity[] entities);
         Task InsertAsync(IEnumerable<TEntity> entities, CancellationToken cancellationToken = default);
         void Update(TEntity entity);

--- a/src/EfCore.UnitOfWork/UnitOfWork.cs
+++ b/src/EfCore.UnitOfWork/UnitOfWork.cs
@@ -41,9 +41,9 @@ namespace EfCore.UnitOfWork
             return (IRepository<TEntity>)_repositories[type];
         }
 
-        public int ExecuteSqlCommand(string sql, params object[] parameters) => DbContext.Database.ExecuteSqlCommand(sql, parameters);
+        public int ExecuteSqlCommand(string sql, params object[] parameters) => DbContext.Database.ExecuteSqlRaw(sql, parameters);
 
-        public IQueryable<TEntity> FromSql<TEntity>(string sql, params object[] parameters) where TEntity : class => DbContext.Set<TEntity>().FromSql(sql, parameters);
+        public IQueryable<TEntity> FromSql<TEntity>(string sql, params object[] parameters) where TEntity : class => DbContext.Set<TEntity>().FromSqlRaw(sql, parameters);
 
         public int SaveChanges(bool ensureAutoHistory = false)
         {


### PR DESCRIPTION
Added support for version 3.1 of the framework.

Breaking Changes:

- The GetProjectedListAsync method of Repository does the projection on the client-side due to the limitation of IQueryable in EF Core 3.x. See https://docs.microsoft.com/en-us/ef/core/querying/client-eval

