### PR TITLE
Upgrade to .NET core 5.0

### DIFF
--- a/src/EfCore.UnitOfWork.UnitTests/EfCore.UnitOfWork.UnitTests.csproj
+++ b/src/EfCore.UnitOfWork.UnitTests/EfCore.UnitOfWork.UnitTests.csproj
@@ -1,14 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <RootNamespace>EfCore.UnitOfWork.UnitTests</RootNamespace>
+    <LangVersion>latestmajor</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.1.9" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="5.0.6" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>

--- a/src/EfCore.UnitOfWork/EfCore.UnitOfWork.csproj
+++ b/src/EfCore.UnitOfWork/EfCore.UnitOfWork.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Description>A minimalistic extension to Microsoft.EntityFrameworkCore for supporting repository and unit of work patterns</Description>
     <Authors>Mohammad Moattar</Authors>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -12,10 +12,11 @@
     <RootNamespace>EfCore.UnitOfWork</RootNamespace>
     <PackageVersion>1.0.0</PackageVersion>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <LangVersion>latestmajor</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore.AutoHistory" Version="3.1.3" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="3.1.9" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.9" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="5.0.6" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.6" />
   </ItemGroup>
 </Project>

--- a/src/EfCore.UnitOfWork/Extensions/PagingOptions.cs
+++ b/src/EfCore.UnitOfWork/Extensions/PagingOptions.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace EfCore.UnitOfWork.Extensions
 {
-    public class PagingOptions
+    public sealed class PagingOptions
     {
         private const int DefaultPageSize = 20;
 

--- a/src/EfCore.UnitOfWork/UnitOfWork.cs
+++ b/src/EfCore.UnitOfWork/UnitOfWork.cs
@@ -22,8 +22,7 @@ namespace EfCore.UnitOfWork
 
         public IRepository<TEntity> GetRepository<TEntity>(bool hasCustomRepository = false) where TEntity : class
         {
-            if (_repositories == null) 
-                _repositories = new Dictionary<Type, object>();
+            _repositories ??= new Dictionary<Type, object>();
 
             // TODO: Find a better way of resolving the repository
             if (hasCustomRepository)


### PR DESCRIPTION
The change is the upgrade of the project to .NET 5.0. 

**Breaking change**
- Entity Framework 5.0 has a dependency on .NET Standard 2.1 so this will cause an upgrade for this library too
